### PR TITLE
Update settings.py

### DIFF
--- a/samplesite/settings.py
+++ b/samplesite/settings.py
@@ -78,7 +78,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'OPTIONS': {
-            'read_default_file': '/code/my.cnf',
+            'read_default_file': '/code/django.app/my.cnf',
         },
     }
 }


### PR DESCRIPTION
some incorrect info, the file path is wrong
# samplesite/settings.py
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.mysql',
        'OPTIONS': {
            **#'read_default_file': '/code/my.cnf',
            'read_default_file': '/code/django.app/my.cnf',**
        },
    }
}